### PR TITLE
feat: auto-resolve pfbid via Graph API before falling back to iframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,15 @@
 ## 功能
 
 - 當瀏覽 Facebook 文章頁面時（格式：`https://www.facebook.com/<account_name>/posts/pfbidXXXXXXX`）
-- 點擊擴充功能按鈕開啟彈出視窗，直接在視窗內顯示嵌入的 Facebook 文章
+- 點擊擴充功能按鈕開啟彈出視窗，會**自動**透過 Facebook Graph API 嘗試解析出數字 ID，成功就直接顯示還原後的完整網址，不需要任何帳號或 access token
+- 如果自動解析失敗，會自動退回原本的方式：直接在視窗內顯示嵌入的 Facebook 文章，從中手動複製包含數字 ID 的真實 URL
 - 或使用右鍵選單，在新分頁中開啟 Facebook 嵌入頁面
-- 從嵌入的文章中可以手動複製包含數字 ID 的真實 URL
 
 ## 靈感來源
 
 本擴充功能的實作靈感來自於 [這個 stack overflow 的回答](https://stackoverflow.com/a/76897937) 其中所指引到的 [Hacker News 討論內容](https://news.ycombinator.com/item?id=32118095)，在此致謝。
+
+另外，自動解析的部分利用了 Facebook Graph API 的一個特性：呼叫 `https://graph.facebook.com/posts/{pfbid}` 時，Facebook 會先把 pfbid 解析成內部的數字 ID，接著才進行權限檢查；如果沒有權限存取，回傳的錯誤訊息裡仍然會包含這個已經解析出來的數字 ID。因為 ID 解析發生在權限檢查「之前」，所以整個過程完全不需要 access token。
 
 ## 下載安裝
 
@@ -45,9 +47,9 @@
 
 1. 開啟任何 Facebook 單一文章頁面（URL 包含 pfbid）
 2. 點擊瀏覽器工具列上的擴充功能按鈕
-3. 彈出視窗會顯示目前網址並載入嵌入版本的文章
-4. 在嵌入的文章中，右鍵點擊「發文時間」連結
-5. 選擇「複製鏈結」即可取得包含數字 ID 的真實網址
+3. 彈出視窗會顯示目前網址，並自動嘗試透過 Graph API 解析
+4. 解析成功時，會直接顯示數字 ID 與還原後的完整網址，點擊「複製網址」即可複製
+5. 若解析失敗，會自動改為載入嵌入版本的文章：在嵌入的文章中右鍵點擊「發文時間」連結，選擇「複製鏈結」即可取得包含數字 ID 的真實網址
 6. 點擊網址區域可以複製目前頁面網址
 
 ### 方法二：使用右鍵選單
@@ -74,8 +76,8 @@ fb-post-url-unhash/
 ## 技術細節
 
 - 使用 Manifest V3 (支援 Firefox、Chrome、Edge 等瀏覽器)
-- 需要 activeTab 權限以及 contextMenus 權限
-- 彈出視窗使用 iframe 直接嵌入 Facebook 文章，提供即時預覽
+- 需要 activeTab 權限、contextMenus 權限，以及呼叫 Graph API 所需的 graph.facebook.com host 權限
+- 彈出視窗會先呼叫 `https://graph.facebook.com/posts/{pfbid}` 自動解析數字 ID，失敗時才 fallback 用 iframe 直接嵌入 Facebook 文章
 - 右鍵選單僅在符合 Facebook 文章格式的頁面上顯示
 - 新分頁會在目前分頁的下一個位置開啟，改善使用體驗
 - 使用 encodeURIComponent 正確編碼 URL 參數
@@ -84,13 +86,14 @@ fb-post-url-unhash/
 ## 注意事項
 
 - 此擴充功能僅在包含 `pfbid` 的 Facebook 文章 URL 上工作
-- 彈出視窗功能需要 Facebook 允許 iframe 嵌入，如果無法載入會提供新分頁開啟的備用選項
-- 需要手動從嵌入的文章中複製發文時間連結來取得數字 ID URL
-- 右鍵選單僅在符合條件的 Facebook 文章頁面上出現
+- Graph API 自動解析不需要任何帳號或 access token，但仍需要該 pfbid 對應的貼文是 Facebook 可以正常解析的物件；解析失敗時會自動 fallback
+- 彈出視窗的 fallback 流程需要 Facebook 允許 iframe 嵌入，如果無法載入會提供新分頁開啟的備用選項
+- 右鍵選單僅在符合條件的 Facebook 文章頁面上出現，且維持原本的嵌入流程（不會自動呼叫 Graph API）
 - 開發者模式載入的擴充功能可能需要在瀏覽器重啟後重新載入
 
 ## 故障排除
 
+- 如果彈出視窗顯示「Graph API 解析失敗，已改用嵌入版本顯示」，代表自動解析失敗，請改用嵌入文章中「複製鏈結」的手動方式
 - 如果彈出視窗中的嵌入文章無法載入，請使用「在新分頁中開啟」按鈕
 - 如果右鍵選單沒有出現，請確認目前頁面是 Facebook 文章且 URL 包含 pfbid
 - 點擊彈出視窗中的網址區域可以複製目前頁面的網址

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -58,5 +58,29 @@
   "contextMenuTitle": {
     "message": "Reopen this post in embed format",
     "description": "Context menu item title"
+  },
+  "graphResolving": {
+    "message": "Resolving via Graph API...",
+    "description": "Graph API resolving status text"
+  },
+  "graphResolvedNumericId": {
+    "message": "Numeric ID:",
+    "description": "Graph API result: numeric ID label"
+  },
+  "graphResolvedUrl": {
+    "message": "Resolved URL:",
+    "description": "Graph API result: resolved URL label"
+  },
+  "graphCopyButton": {
+    "message": "Copy URL",
+    "description": "Button text: copy resolved URL"
+  },
+  "graphCopiedMessage": {
+    "message": "Copied!",
+    "description": "Copy success message"
+  },
+  "graphFallbackNotice": {
+    "message": "Graph API resolution failed, falling back to embed method.",
+    "description": "Notice shown when Graph API resolution fails and falls back to iframe"
   }
 }

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -58,5 +58,29 @@
   "contextMenuTitle": {
     "message": "以嵌入格式重開此文章",
     "description": "右鍵選單項目標題"
+  },
+  "graphResolving": {
+    "message": "正在透過 Graph API 解析中...",
+    "description": "Graph API 解析中狀態文字"
+  },
+  "graphResolvedNumericId": {
+    "message": "數字 ID：",
+    "description": "Graph API 解析結果：數字 ID 標籤"
+  },
+  "graphResolvedUrl": {
+    "message": "還原網址：",
+    "description": "Graph API 解析結果：還原網址標籤"
+  },
+  "graphCopyButton": {
+    "message": "複製網址",
+    "description": "複製還原網址按鈕文字"
+  },
+  "graphCopiedMessage": {
+    "message": "已複製！",
+    "description": "複製成功提示文字"
+  },
+  "graphFallbackNotice": {
+    "message": "Graph API 解析失敗，已改用嵌入版本顯示。",
+    "description": "Graph API 解析失敗改用 iframe 的提示文字"
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -15,9 +15,10 @@
   "permissions": [
     "activeTab",
     "contextMenus",
-    "*://www.facebook.com/*"
+    "*://www.facebook.com/*",
+    "*://graph.facebook.com/*"
   ],
-  "content_security_policy": "script-src 'self'; object-src 'self'; frame-src https://www.facebook.com;",
+  "content_security_policy": "script-src 'self'; object-src 'self'; frame-src https://www.facebook.com; connect-src https://graph.facebook.com;",
   "browser_action": {
     "default_icon": "icons/icon-64.png",
     "default_title": "__MSG_browserActionTitle__",

--- a/popup.html
+++ b/popup.html
@@ -62,6 +62,42 @@
       border-radius: 4px;
       display: none;
     }
+
+    .graph-result {
+      padding: 15px;
+      font-size: 12px;
+      color: #333;
+      display: none;
+    }
+
+    .graph-result p {
+      margin: 4px 0 12px 0;
+    }
+
+    .graph-result strong {
+      display: block;
+      margin-bottom: 2px;
+    }
+
+    .graph-result a {
+      word-break: break-all;
+      color: #1877f2;
+    }
+
+    .graph-result button {
+      margin-top: 4px;
+    }
+
+    .graph-fallback-notice {
+      background-color: #fff3cd;
+      border: 1px solid #ffc107;
+      padding: 8px;
+      margin: 5px;
+      font-size: 11px;
+      color: #856404;
+      border-radius: 4px;
+      display: none;
+    }
   </style>
 </head>
 <body>
@@ -70,11 +106,19 @@
   <div id="instruction" class="instruction">
     <strong data-i18n="instructionTitle"></strong><span data-i18n="instructionText"></span>
   </div>
+  <div id="graph-fallback-notice" class="graph-fallback-notice" data-i18n="graphFallbackNotice"></div>
   <div class="content">
     <div id="loading" class="loading" data-i18n="loading"></div>
     <div id="error" class="error" style="display: none;">
       <p data-i18n="errorInvalidUrl"></p>
       <p data-i18n="errorUrlFormat"></p>
+    </div>
+    <div id="graph-result" class="graph-result">
+      <strong data-i18n="graphResolvedNumericId"></strong>
+      <p id="graph-numeric-id"></p>
+      <strong data-i18n="graphResolvedUrl"></strong>
+      <p><a id="graph-resolved-url" href="#" target="_blank" rel="noopener"></a></p>
+      <button id="graph-copy-button" data-i18n="graphCopyButton"></button>
     </div>
     <iframe id="embed-frame" style="display: none;"></iframe>
   </div>

--- a/popup.js
+++ b/popup.js
@@ -61,6 +61,67 @@ function isFacebookPostUrl(url) {
   }
 }
 
+// 從網址中找出 pfbid，並提供一個組出還原後網址的函式
+function extractPfbidInfo(url) {
+  try {
+    const urlObj = new URL(url);
+
+    if (urlObj.hostname !== 'www.facebook.com') {
+      return null;
+    }
+
+    // 類型 1: https://www.facebook.com/{username}/posts/pfbid...
+    const pathMatch = urlObj.pathname.match(/^\/[^\/]+\/posts\/(pfbid[^\/?]+)/);
+    if (pathMatch) {
+      const pfbid = pathMatch[1];
+      return {
+        pfbid,
+        buildResolvedUrl: (numericId) => {
+          const resolved = new URL(url);
+          resolved.pathname = resolved.pathname.replace(pfbid, numericId);
+          return resolved.toString();
+        }
+      };
+    }
+
+    // 類型 2/3: story_fbid=pfbid...
+    if (urlObj.pathname === '/permalink.php' || urlObj.pathname === '/story.php') {
+      const storyFbid = urlObj.searchParams.get('story_fbid');
+      if (storyFbid && storyFbid.startsWith('pfbid')) {
+        return {
+          pfbid: storyFbid,
+          buildResolvedUrl: (numericId) => {
+            const resolved = new URL(url);
+            resolved.searchParams.set('story_fbid', numericId);
+            return resolved.toString();
+          }
+        };
+      }
+    }
+
+    // 類型 4 (photo.php) 或純數字 story_fbid：沒有 pfbid 需要還原
+    return null;
+  } catch (error) {
+    return null;
+  }
+}
+
+// 呼叫 Graph API，從錯誤訊息中取得數字 ID（不需要 access token）
+async function resolvePfbidViaGraphApi(pfbid) {
+  const apiUrl = `https://graph.facebook.com/posts/${encodeURIComponent(pfbid)}`;
+  const response = await fetch(apiUrl);
+  const data = await response.json();
+  const message = data && data.error && data.error.message;
+  if (!message) {
+    throw new Error('Graph API did not return a parseable error message');
+  }
+  const match = message.match(/\d{10,}/);
+  if (!match) {
+    throw new Error('Could not find a numeric ID in the Graph API error message');
+  }
+  return match[0];
+}
+
 // Popup script for handling the embedded Facebook post (Manifest V3 compatible)
 document.addEventListener('DOMContentLoaded', async () => {
   // Initialize i18n texts
@@ -70,6 +131,71 @@ document.addEventListener('DOMContentLoaded', async () => {
   const errorEl = document.getElementById('error');
   const iframeEl = document.getElementById('embed-frame');
   const urlInfoEl = document.getElementById('url-info');
+  const graphResultEl = document.getElementById('graph-result');
+  const graphFallbackNoticeEl = document.getElementById('graph-fallback-notice');
+
+  // 載入嵌入版本的文章（原本的手動流程）
+  function loadIframeMethod(currentUrl) {
+    const encodedUrl = encodeURIComponent(currentUrl);
+    const embedUrl = `https://www.facebook.com/plugins/post.php?href=${encodedUrl}`;
+
+    loadingEl.style.display = 'block';
+    loadingEl.textContent = browserAPI.i18n.getMessage('loading');
+
+    // Load the embedded post
+    iframeEl.src = embedUrl;
+
+    // Show iframe and hide loading when loaded
+    iframeEl.onload = () => {
+      loadingEl.style.display = 'none';
+      iframeEl.style.display = 'block';
+
+      // Show instruction message
+      const instructionEl = document.getElementById('instruction');
+      if (instructionEl) {
+        instructionEl.style.display = 'block';
+      }
+    };
+
+    // Handle iframe load errors
+    iframeEl.onerror = () => {
+      loadingEl.style.display = 'none';
+      errorEl.innerHTML = `<p>${browserAPI.i18n.getMessage('errorCannotLoad')}</p><p>${browserAPI.i18n.getMessage('errorTryNewTab')}</p>`;
+      errorEl.style.display = 'block';
+
+      // Add a button to open in new tab as fallback
+      const openButton = document.createElement('button');
+      openButton.textContent = browserAPI.i18n.getMessage('openInNewTab');
+      openButton.style.marginTop = '10px';
+      openButton.onclick = () => {
+        browserAPI.tabs.create({ url: embedUrl });
+        window.close();
+      };
+      errorEl.appendChild(openButton);
+    };
+  }
+
+  // 顯示 Graph API 解析出來的結果
+  function showGraphResult(numericId, resolvedUrl) {
+    loadingEl.style.display = 'none';
+
+    document.getElementById('graph-numeric-id').textContent = numericId;
+    const resolvedUrlEl = document.getElementById('graph-resolved-url');
+    resolvedUrlEl.textContent = resolvedUrl;
+    resolvedUrlEl.href = resolvedUrl;
+
+    graphResultEl.style.display = 'block';
+
+    document.getElementById('graph-copy-button').onclick = (e) => {
+      navigator.clipboard.writeText(resolvedUrl);
+      const button = e.target;
+      const originalText = button.textContent;
+      button.textContent = browserAPI.i18n.getMessage('graphCopiedMessage');
+      setTimeout(() => {
+        button.textContent = originalText;
+      }, 1000);
+    };
+  }
 
   try {
     // Get the current active tab
@@ -82,41 +208,24 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     // Check if the current URL is a Facebook post with pfbid
     if (isFacebookPostUrl(currentUrl)) {
-      // Create the embed URL
-      const encodedUrl = encodeURIComponent(currentUrl);
-      const embedUrl = `https://www.facebook.com/plugins/post.php?href=${encodedUrl}`;
+      const pfbidInfo = extractPfbidInfo(currentUrl);
 
-      // Load the embedded post
-      iframeEl.src = embedUrl;
+      if (pfbidInfo) {
+        loadingEl.style.display = 'block';
+        loadingEl.textContent = browserAPI.i18n.getMessage('graphResolving');
 
-      // Show iframe and hide loading when loaded
-      iframeEl.onload = () => {
-        loadingEl.style.display = 'none';
-        iframeEl.style.display = 'block';
-
-        // Show instruction message
-        const instructionEl = document.getElementById('instruction');
-        if (instructionEl) {
-          instructionEl.style.display = 'block';
+        try {
+          const numericId = await resolvePfbidViaGraphApi(pfbidInfo.pfbid);
+          const resolvedUrl = pfbidInfo.buildResolvedUrl(numericId);
+          showGraphResult(numericId, resolvedUrl);
+        } catch (graphError) {
+          console.error('Graph API resolve failed:', graphError);
+          graphFallbackNoticeEl.style.display = 'block';
+          loadIframeMethod(currentUrl);
         }
-      };
-
-      // Handle iframe load errors
-      iframeEl.onerror = () => {
-        loadingEl.style.display = 'none';
-        errorEl.innerHTML = `<p>${browserAPI.i18n.getMessage('errorCannotLoad')}</p><p>${browserAPI.i18n.getMessage('errorTryNewTab')}</p>`;
-        errorEl.style.display = 'block';
-
-        // Add a button to open in new tab as fallback
-        const openButton = document.createElement('button');
-        openButton.textContent = browserAPI.i18n.getMessage('openInNewTab');
-        openButton.style.marginTop = '10px';
-        openButton.onclick = () => {
-          browserAPI.tabs.create({ url: embedUrl });
-          window.close();
-        };
-        errorEl.appendChild(openButton);
-      };
+      } else {
+        loadIframeMethod(currentUrl);
+      }
 
     } else {
       // Show error for invalid URL


### PR DESCRIPTION
Facebook's Graph API resolves the pfbid to its internal numeric ID before running permission checks, so hitting graph.facebook.com/posts/{pfbid} leaks the numeric ID in the error message without needing any access token. The popup now tries this automatically and only falls back to the manual iframe embed flow if it fails.

fix #1 