### PR TITLE
fix: parse Edge Add-ons Location header correctly + document release setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -326,7 +326,7 @@ jobs:
 
         echo "$UPLOAD_HEADERS"
 
-        OPERATION_ID=$(echo "$UPLOAD_HEADERS" | grep -i '^Location:' | sed -E 's#.*/operations/([^/[:space:]]+).*#\1#')
+        OPERATION_ID=$(echo "$UPLOAD_HEADERS" | grep -i '^Location:' | sed -E 's/^[Ll]ocation:[[:space:]]*//' | tr -d '\r' | sed -E 's#.*/##')
 
         if [ -z "$OPERATION_ID" ]; then
           echo "Failed to upload package (no operation ID in response)"
@@ -372,7 +372,7 @@ jobs:
 
         echo "$PUBLISH_HEADERS"
 
-        PUBLISH_OPERATION_ID=$(echo "$PUBLISH_HEADERS" | grep -i '^Location:' | sed -E 's#.*/operations/([^/[:space:]]+).*#\1#')
+        PUBLISH_OPERATION_ID=$(echo "$PUBLISH_HEADERS" | grep -i '^Location:' | sed -E 's/^[Ll]ocation:[[:space:]]*//' | tr -d '\r' | sed -E 's#.*/##')
 
         if [ -z "$PUBLISH_OPERATION_ID" ]; then
           echo "Failed to create submission (no operation ID in response)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -326,7 +326,7 @@ jobs:
 
         echo "$UPLOAD_HEADERS"
 
-        OPERATION_ID=$(echo "$UPLOAD_HEADERS" | grep -i '^Location:' | sed -E 's/^[Ll]ocation:[[:space:]]*//' | tr -d '\r' | sed -E 's#.*/##')
+        OPERATION_ID=$(echo "$UPLOAD_HEADERS" | grep -i '^Location:' | sed -E 's/^[Ll]ocation:[[:space:]]*//' | tr -d '\r')
 
         if [ -z "$OPERATION_ID" ]; then
           echo "Failed to upload package (no operation ID in response)"
@@ -372,7 +372,7 @@ jobs:
 
         echo "$PUBLISH_HEADERS"
 
-        PUBLISH_OPERATION_ID=$(echo "$PUBLISH_HEADERS" | grep -i '^Location:' | sed -E 's/^[Ll]ocation:[[:space:]]*//' | tr -d '\r' | sed -E 's#.*/##')
+        PUBLISH_OPERATION_ID=$(echo "$PUBLISH_HEADERS" | grep -i '^Location:' | sed -E 's/^[Ll]ocation:[[:space:]]*//' | tr -d '\r')
 
         if [ -z "$PUBLISH_OPERATION_ID" ]; then
           echo "Failed to create submission (no operation ID in response)"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -67,17 +67,32 @@
 
 | Secret 名稱 | 說明 | 取得方式 |
 |------------|------|---------|
-| `CHROME_EXTENSION_ID` | 擴充功能 ID | Chrome Web Store URL 中的 ID |
+| `CHROME_EXTENSION_ID` | 擴充功能 ID | Chrome Web Store Developer Dashboard |
 | `CHROME_CLIENT_ID` | OAuth2 Client ID | [Google Cloud Console](https://console.cloud.google.com/) |
 | `CHROME_CLIENT_SECRET` | OAuth2 Client Secret | Google Cloud Console |
 | `CHROME_REFRESH_TOKEN` | OAuth2 Refresh Token | 使用 OAuth2 流程取得 |
 
 **取得 Chrome API 憑證步驟**：
 
-1. 前往 [Google Cloud Console](https://console.cloud.google.com/)
-2. 建立專案並啟用 Chrome Web Store API
-3. 建立 OAuth2 憑證（Desktop App 類型）
-4. 使用 OAuth2 授權流程取得 refresh token
+1. 前往 [Google Cloud Console](https://console.cloud.google.com/)，建立/選擇專案，啟用 **Chrome Web Store API**
+2. 設定「OAuth 同意畫面」，填基本資訊（App name、support email 等）即可
+3. 「憑證」→「建立憑證」→「OAuth 用戶端 ID」，應用程式類型選 **「網頁應用程式 (Web application)」**（不要選 Desktop app，Desktop 類型無法設定下面要用的重新導向 URI）
+4. 在「已授權的重新導向 URI」加入：
+   ```
+   https://developers.google.com/oauthplayground
+   ```
+5. 建立後記下 **Client ID** 和 **Client secret**
+6. 用 [OAuth Playground](https://developers.google.com/oauthplayground/) 換 refresh token：
+   - 右上齒輪 ⚙️ 勾選「Use your own OAuth credentials」，填入上面的 Client ID/Secret
+   - Step 1 手動輸入 scope `https://www.googleapis.com/auth/chromewebstore`，點 Authorize APIs
+   - 用你發布擴充功能的 Google 帳號登入、同意（會看到「未驗證應用程式」警告，點「進階」→「前往...(不安全)」繼續即可，這是正常的，不需要做 Google 品牌驗證）
+   - Step 2 點「Exchange authorization code for tokens」，取得 `refresh_token`
+7. **重要**：如果 OAuth 同意畫面停留在「測試中 (Testing)」狀態，換到的 refresh token 只有 **7 天** 效期（回應會有 `refresh_token_expires_in: 604799`）。回「OAuth 同意畫面」點 **「發布應用程式 (Publish App)」** 改成「正式版 (In production)」（不需要送 Google 驗證，因為 `chromewebstore` 是 sensitive scope、非 restricted scope，個人使用不受 100 人上限影響），改完**重新走一次 Playground 授權流程**拿新的 refresh token，這次回應就不會再有 `refresh_token_expires_in` 欄位，代表長期有效
+8. Extension ID 是在 [Chrome Web Store Developer Dashboard](https://chrome.google.com/webstore/devconsole)（需付一次性 $5 註冊費）上傳過一次草稿後，項目清單/網址列上的那組 32 碼字串
+
+**踩過的坑**：
+- 授權網址如果手動組，容易漏字/多字（例如 client_id 結尾漏或多打字元）導致 `invalid_client`，建議從 Cloud Console 直接複製貼上
+- 部分瀏覽器擴充功能（廣告攔截/隱私類）會攔截、改寫 OAuth 重新導向網址的參數，導致 Google 端出現籠統的 `unknownerror`，換一個沒裝該擴充功能的瀏覽器或用無痕視窗即可解決
 
 #### Firefox Add-ons (AMO)
 
@@ -94,18 +109,26 @@
 
 #### Microsoft Edge Add-ons
 
+使用 [Edge Add-ons Update API v1.1](https://learn.microsoft.com/en-us/microsoft-edge/extensions/update/api/using-addons-api)，用 API Key 驗證，**不需要**自己去 Azure Portal 建立/關聯 Entra ID (Azure AD) 租用戶。
+
 | Secret 名稱 | 說明 | 取得方式 |
 |------------|------|---------|
-| `EDGE_PRODUCT_ID` | Edge 擴充功能 Product ID | Partner Center |
-| `EDGE_CLIENT_ID` | Azure AD App Client ID | Azure Portal |
-| `EDGE_CLIENT_SECRET` | Azure AD App Client Secret | Azure Portal |
-| `EDGE_ACCESS_TOKEN_URL` | Token URL | `https://login.microsoftonline.com/{tenant-id}/oauth2/v2.0/token` |
+| `EDGE_PRODUCT_ID` | Edge 擴充功能 Product ID | Partner Center 擴充功能總覽頁 |
+| `EDGE_CLIENT_ID` | API Client ID | Partner Center「Publish API」頁面 |
+| `EDGE_API_KEY` | API Key | Partner Center「Publish API」頁面 |
 
 **取得 Edge API 憑證步驟**：
 
-1. 前往 [Partner Center](https://partner.microsoft.com/dashboard)
-2. 在 Azure Portal 註冊應用程式
-3. 設定 API 權限並取得憑證
+1. 前提：需要有 [Partner Center](https://partner.microsoft.com/dashboard) 開發者帳號，且該擴充功能已經手動上架過一次
+2. 前往 [Partner Center Edge 開發者儀表板](https://partner.microsoft.com/dashboard/microsoftedge/public/login)
+3. 左側選單 **Microsoft Edge** → **Publish API**
+4. 點 **「Create API credentials」**（第一次啟用可能要等幾分鐘）
+5. 畫面會直接顯示 **Client ID** 和 **API key**，記下來（API key 只會顯示一次）
+6. Product ID：Partner Center → **Microsoft Edge** → **Overview**，點進該擴充功能，總覽頁 / 網址列會有一組 GUID
+
+**踩過的坑**：
+- ⚠️ **不要走「帳戶設定 → 使用者管理 → Microsoft Entra Apps」那條路** 手動建立 Azure AD App 走 OAuth client_credentials 流程 —— 這是給其他 Partner Center 用途的通用機制，用在 Edge Add-ons API 上會一直卡在 `AADSTS500014: The service principal for resource 'https://api.addons.microsoftedge.microsoft.com' is disabled`，即使手動建立 Entra 租用戶、關聯、產生 admin consent 都無法解決
+- 正確路徑是上面這個「Publish API」頁面，Microsoft 後端會直接幫你建好對應的憑證，完全不用碰 Entra/Azure AD
 
 ---
 
@@ -141,7 +164,7 @@
 |-----|------|------|
 | Chrome Web Store | [Chrome Web Store API](https://developer.chrome.com/docs/webstore/api_update) | Google 官方 REST API |
 | Firefox Add-ons | [web-ext](https://extensionworkshop.com/documentation/develop/web-ext-command-reference/) | Mozilla 官方 CLI 工具 |
-| Edge Add-ons | [Edge Add-ons API](https://learn.microsoft.com/en-us/microsoft-edge/extensions-chromium/publish/api/using-addons-api) | 微軟官方 REST API |
+| Edge Add-ons | [Edge Add-ons Update API v1.1](https://learn.microsoft.com/en-us/microsoft-edge/extensions/update/api/using-addons-api) | 微軟官方 REST API（ApiKey 驗證） |
 
 ---
 


### PR DESCRIPTION
## Summary
- Fix `publish-edge` job: the `Location` response header from the Edge Add-ons API was observed to contain just the raw operation ID (e.g. `25ac3071-b7e4-41c7-a0b9-5b86ef578125`), not a full URL ending in `/operations/<id>`. The previous regex assumed the URL shape and silently failed to match, so the whole `Location: ...` line got used as the "operation ID" — this is what caused the failed run. Now strips the `Location:` prefix directly and only takes the last path segment if a slash is present, handling both shapes.
- Document the full Chrome / Firefox / Edge auto-publish secret setup in `RELEASE.md`, including gotchas hit while setting this up:
  - Chrome OAuth client must be **Web application** type (not Desktop) to set the OAuth Playground redirect URI, and the consent screen needs to be **published to Production** to avoid 7-day refresh token expiry
  - Edge Add-ons now uses the **v1.1 ApiKey flow** via Partner Center's "Publish API" page — explicitly warns against the old Entra Apps / Azure AD tenant association path, which reliably fails with `AADSTS500014`

## Test plan
- [ ] Trigger `Create Release` via `workflow_dispatch` with `publish_edge` checked and confirm the operation ID is parsed correctly and the run succeeds